### PR TITLE
fix nombre de paquete en composer

### DIFF
--- a/php_prueba/composer.json
+++ b/php_prueba/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "paw/cursada Pilar",
+    "name": "paw/cursada-pilar",
     "type": "library",
     "license": "MIT",
     "homepage": "https://github.com/viccmedina/PAW_2020/blob/master/php_prueba/README.md",


### PR DESCRIPTION
A partir de nuevas versiones de composer, el nombre será invalido si tiene espacios en blanco [1]

[1]: https://getcomposer.org/doc/04-schema.md#name